### PR TITLE
Conservative dep updates

### DIFF
--- a/Tomighty.Core.Test/Tomighty.Core.Test.csproj
+++ b/Tomighty.Core.Test/Tomighty.Core.Test.csproj
@@ -57,13 +57,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Tomighty.Core\Tomighty.Core.csproj">
       <Project>{C7FF3B3E-0CC1-4EC7-A7C1-39B6361B5895}</Project>
       <Name>Tomighty.Core</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Tomighty.Core.Test/Tomighty.Core.Test.csproj
+++ b/Tomighty.Core.Test/Tomighty.Core.Test.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.14.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.14.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,11 +36,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NSubstitute, Version=2.0.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca">
-      <HintPath>..\packages\NSubstitute.2.0.0-rc\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
-      <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.14.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.14.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -63,6 +66,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.14.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.14.0\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tomighty.Core.Test/packages.config
+++ b/Tomighty.Core.Test/packages.config
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NSubstitute" version="2.0.0-rc" targetFramework="net45" />
-  <package id="NUnit" version="3.4.1" targetFramework="net45" />
-  <package id="NUnit.ConsoleRunner" version="3.4.1" targetFramework="net45" />
-  <package id="NUnit.Extension.NUnitProjectLoader" version="3.4.1" targetFramework="net45" />
-  <package id="NUnit.Extension.NUnitV2Driver" version="3.4.1" targetFramework="net45" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.4.1" targetFramework="net45" />
-  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.1" targetFramework="net45" />
-  <package id="NUnit.Extension.VSProjectLoader" version="3.4.1" targetFramework="net45" />
-  <package id="NUnit.Runners" version="3.4.1" targetFramework="net45" />
+  <package id="NSubstitute" version="2.0.3" targetFramework="net48" />
+  <package id="NUnit" version="3.14.0" targetFramework="net48" />
+  <package id="NUnit.Console" version="3.20.1" targetFramework="net48" />
+  <package id="NUnit.ConsoleRunner" version="3.20.1" targetFramework="net48" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.8.0" targetFramework="net48" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.9.0" targetFramework="net48" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.8.0" targetFramework="net48" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.10" targetFramework="net48" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.9.0" targetFramework="net48" />
+  <package id="NUnit.Runners" version="3.12.0" targetFramework="net48" />
 </packages>

--- a/Tomighty.Windows/Tomighty.Windows.csproj
+++ b/Tomighty.Windows/Tomighty.Windows.csproj
@@ -70,9 +70,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
-    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.XML" />
     <Reference Include="Windows.Data" />
@@ -242,7 +239,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
+    <Error Condition="!Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets'))" />
   </Target>
+  <Import Project="..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets" Condition="Exists('..\packages\System.ValueTuple.4.6.1\build\net471\System.ValueTuple.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tomighty.Windows/packages.config
+++ b/Tomighty.Windows/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GitVersionTask" version="3.6.5" targetFramework="net452" developmentDependency="true" />
-  <package id="Microsoft.Toolkit.Uwp.Notifications" version="6.0.0" targetFramework="net472" />
+  <package id="GitVersionTask" version="3.6.5" targetFramework="net48" developmentDependency="true" />
+  <package id="Microsoft.Toolkit.Uwp.Notifications" version="6.0.0" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.6.1" targetFramework="net48" />
 </packages>

--- a/Tomighty.Windows/packages.config
+++ b/Tomighty.Windows/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="GitVersionTask" version="3.6.5" targetFramework="net452" developmentDependency="true" />
   <package id="Microsoft.Toolkit.Uwp.Notifications" version="6.0.0" targetFramework="net472" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.6.1" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Taking it easy on dependency updates, avoiding bringing in a host of other dependencies. Less bothered about the test project, because that isn't packaged in the release.